### PR TITLE
Parse pipe angles

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "redprl",
   "displayName": "RedPRL",
   "description": "RedPRL language support",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "publisher": "freebroccolo",
   "license": "Apache-2.0",
   "bugs": {

--- a/syntaxes/redprl.json
+++ b/syntaxes/redprl.json
@@ -39,6 +39,7 @@
       "patterns": [
         { "include": "#comment" },
         { "include": "#keyword" },
+        { "include": "#body-pipe-angles" },
         { "include": "#body-angles" },
         { "include": "#body-braces" },
         { "include": "#body-parens" },
@@ -62,6 +63,13 @@
           "match": "\\b([[:word:]]+)\\b",
           "name": "constant.language support.property-value entity.name.filename variable.interpolation"
         }
+      ]
+    },
+    "body-pipe-angles": {
+      "begin": "<\\|",
+      "end": "\\|>",
+      "patterns": [
+        { "include": "#body" }
       ]
     },
     "body-braces": {


### PR DESCRIPTION
`<| t |>` runs a tactic in "depth-first" mode.