### PR TITLE
Add outline view to explorer panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,5 +98,7 @@
   "dependencies": {
     "lodash": "^4.17.4"
   },
-  "extensionDependencies": []
+  "extensionDependencies": [
+    "patrys.vscode-code-outline"
+  ]
 }


### PR DESCRIPTION
@jonsterling this adds the data from the command palette outline navigation thing to a tree view in the explorer side panel (via the extension dependency). If you think this is okay I can push a new version with the change.